### PR TITLE
Ignore mimeType and finished flags in ConsumptionReportingUnit 

### DIFF
--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/consumptionReporting/ConsumptionReport.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/consumptionReporting/ConsumptionReport.kt
@@ -32,9 +32,9 @@ data class ConsumptionReportingUnit(
     val startTime: String,
     var duration: Int,
     var locations: ArrayList<TypedLocation>? = ArrayList(),
-    //@JsonIgnore
+    @JsonIgnore
     var mimeType: String? = null,
-    //@JsonIgnore
+    @JsonIgnore
     var finished: Boolean = false
 ) : Parcelable
 


### PR DESCRIPTION
Ignore mimeType and finished flags in ConsumptionReportingUnit as they should not be included in the final consumption report.

Addresses https://github.com/5G-MAG/rt-5gms-media-stream-handler/issues/59#issuecomment-1798535014