### PR TITLE
Add required classes for QoE metrics reporting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdk 29
         targetSdk 32
         versionCode 1
-        versionName "1.1.0"
+        versionName "1.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -38,7 +38,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.fivegmag'
             artifactId = 'a5gmscommonlibrary'
-            version = '1.1.0'
+            version = '1.2.0'
 
             afterEvaluate {
                 from components.release
@@ -64,6 +64,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.8.0'
     implementation "androidx.media3:media3-exoplayer:1.0.2"
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.0'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/eventbus/MediaStreamHandlerMessageEvents.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/eventbus/MediaStreamHandlerMessageEvents.kt
@@ -20,6 +20,11 @@ class LoadStartedEvent(
     val loadEventInfo: LoadEventInfo,
     val mediaLoadData: MediaLoadData
 )
+class LoadCompletedEvent(
+    val eventTime: EventTime,
+    val loadEventInfo: LoadEventInfo,
+    val mediaLoadData: MediaLoadData
+)
 
 class CellInfoUpdatedEvent(
     val cellInfoList: MutableList<CellInfo>

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/eventbus/MediaStreamHandlerMessageEvents.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/eventbus/MediaStreamHandlerMessageEvents.kt
@@ -1,3 +1,12 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
 package com.fivegmag.a5gmscommonlibrary.eventbus
 
 import android.telephony.CellInfo

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/helpers/Constants.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/helpers/Constants.kt
@@ -33,13 +33,16 @@ object SessionHandlerMessageTypes {
     const val UNREGISTER_CLIENT = 5
     const val START_PLAYBACK_BY_MEDIA_PLAYER_ENTRY_MESSAGE = 6
     const val SESSION_HANDLER_TRIGGERS_PLAYBACK = 6
-    const val METRIC_REPORTING_MESSAGE = 7
-    const val UPDATE_LOOKUP_TABLE = 8
-    const val SET_M5_ENDPOINT = 9
-    const val START_PLAYBACK_BY_SERVICE_LIST_ENTRY_MESSAGE = 10
-    const val GET_CONSUMPTION_REPORT = 11
-    const val CONSUMPTION_REPORT = 12
-    const val UPDATE_PLAYBACK_CONSUMPTION_REPORTING_CONFIGURATION = 13
+    const val UPDATE_LOOKUP_TABLE = 7
+    const val SET_M5_ENDPOINT = 8
+    const val START_PLAYBACK_BY_SERVICE_LIST_ENTRY_MESSAGE = 9
+    const val GET_CONSUMPTION_REPORT = 10
+    const val CONSUMPTION_REPORT = 11
+    const val UPDATE_PLAYBACK_CONSUMPTION_REPORTING_CONFIGURATION = 12
+    const val GET_QOE_METRICS_CAPABILITIES = 13
+    const val REPORT_QOE_METRICS_CAPABILITIES = 14
+    const val GET_QOE_METRICS_REPORT = 15
+    const val REPORT_QOE_METRICS = 16
 }
 
 object SessionHandlerEvents {
@@ -63,4 +66,25 @@ object HostInfoTypes {
     const val IP_V4 = "ipv4"
     const val IP_V6 = "ipv6"
     const val DOMAIN_NAME = "domain_name"
+}
+
+object MetricReportingSchemes {
+    const val FIVE_G_MAG_EXOPLAYER_COMBINED_PLAYBACK_STATS = "urn:5gmag:exoplayer:combined"
+    const val THREE_GPP_DASH_METRIC_REPORTING = "urn:3GPP:ns:PSS:DASH:QM10"
+}
+
+object Metrics {
+    const val BUFFER_LEVEL = "BufferLevel"
+    const val HTTP_LIST = "HTTPList"
+    const val REP_SWITCH_LIST = "RepSwitchList"
+    const val MPD_INFORMATION = "MPDInformation"
+}
+
+object XmlSchemaStrings {
+    object THREE_GPP_METADATA_2011_HSD_RECEPTION_REPORT {
+        const val SCHEMA = "urn:3gpp:metadata:2011:HSD:receptionreport"
+        const val LOCATION = "DASH-QoE-Report.xsd"
+        const val XSI = "http://www.w3.org/2001/XMLSchema-instance"
+        const val SV = "urn:3gpp:metadata:2016:PSS:schemaVersion"
+    }
 }

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/helpers/Utils.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/helpers/Utils.kt
@@ -1,3 +1,12 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
 package com.fivegmag.a5gmscommonlibrary.helpers
 
 import com.fivegmag.a5gmscommonlibrary.models.EndpointAddress

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/models/MessageModels.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/models/MessageModels.kt
@@ -1,3 +1,12 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
 package com.fivegmag.a5gmscommonlibrary.models
 
 import android.os.Parcelable

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/models/ServiceAccessInformation.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/models/ServiceAccessInformation.kt
@@ -17,7 +17,8 @@ data class ServiceAccessInformation(
     val provisioningSessionId : String,
     val provisioningSessionType: String?,
     val streamingAccess: StreamingAccess,
-    var clientConsumptionReportingConfiguration: ClientConsumptionReportingConfiguration?
+    var clientConsumptionReportingConfiguration: ClientConsumptionReportingConfiguration?,
+    var clientMetricsReportingConfigurations: ArrayList<ClientMetricsReportingConfiguration>?
 ) : Parcelable
 
 @Parcelize
@@ -32,4 +33,19 @@ data class ClientConsumptionReportingConfiguration(
     val samplePercentage: Float,
     val reportingInterval: Int? = null,
     val accessReporting: Boolean
+) : Parcelable
+
+@Parcelize
+data class ClientMetricsReportingConfiguration(
+    val metricsReportingConfigurationId: String,
+    val serverAddresses: ArrayList<String>,
+    val scheme: String,
+    val dataNetworkName: String?,
+    val reportingInterval: Long? = null,
+    val samplePercentage: Float? = null,
+    val urlFilters: ArrayList<String>?,
+    val metrics: ArrayList<String>,
+
+    // These are additional fields that we need for processing. They are not included in the spec and are populated during runtime
+    var isSchemeSupported: Boolean? = false
 ) : Parcelable

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/AverageThroughput.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/AverageThroughput.kt
@@ -1,0 +1,25 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+data class AvgThroughput(
+    val numbytes: Integer,
+    val activitytime: Integer,
+    val t : String,
+    val duration: Integer,
+    val accessbearer: String,
+    val inactivitytype: InactivityType
+)
+
+enum class InactivityType {
+    USER_REQUEST,
+    CLIENT_MEASURE,
+    ERROR
+}

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/BufferLevel.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/BufferLevel.kt
@@ -1,0 +1,26 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+
+data class BufferLevel(
+    @field:JacksonXmlProperty(localName = "BufferLevelEntry")
+    @field:JacksonXmlElementWrapper(useWrapping = false)
+    val entries: ArrayList<BufferLevelEntry>
+)
+
+data class BufferLevelEntry(
+    @field:JacksonXmlProperty(isAttribute = true)
+    val t: String? = null,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val level: Int = 0
+)

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/HttpList.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/HttpList.kt
@@ -1,0 +1,63 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+
+data class HttpList(
+    @field:JacksonXmlElementWrapper(useWrapping = false)
+    @field:JacksonXmlProperty(localName = "HttpListEntry")
+    val entries: ArrayList<HttpListEntry>
+)
+
+data class HttpListEntry(
+    @field:JacksonXmlProperty(isAttribute = true)
+    val tcpid: Int? = null,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val type: String = HttpListEntryType.OTHER.value,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val url: String = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val actualurl: String = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val range: String = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val trequest: String = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val tresponse: String = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val responsecode: Int = 0,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val interval: Int = 0,
+    @field:JacksonXmlProperty(localName = "Trace")
+    @field:JacksonXmlElementWrapper(useWrapping = false)
+    val traces: ArrayList<Trace>
+)
+data class Trace(
+    @field:JacksonXmlProperty(isAttribute = true)
+    val s: String = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val d: Long = -1,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val b: Int = -1,
+)
+
+enum class HttpListEntryType(val value : String) {
+    MPD("MPD"),
+    XLINK_EXPANSION("XLinkExpansion"),
+    INITIALIZATION_SEGMENT("InitializationSegment"),
+    INDEX_SEGMENT("IndexSegment"),
+    MEDIA_SEGMENT("MediaSegment"),
+    BITSTREAM_SWITCHING_SEGMENT("BitstreamSwitchingSegment"),
+    REMOTE_XLINK_ELEMENT("RemoteXLinkElement"),
+    MPD_PATCH("MPDPatch"),
+    OTHER("other")
+}

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/MpdInformation.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/MpdInformation.kt
@@ -1,0 +1,38 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+
+data class MpdInformation(
+    @field:JacksonXmlProperty(isAttribute = true)
+    val representationId: String? = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val subrepLevel: Int? = null,
+    @field:JacksonXmlProperty(localName = "Mpdinfo")
+    val mpdInfo: MpdInfo
+)
+
+data class MpdInfo(
+    @field:JacksonXmlProperty(isAttribute = true)
+    val codecs: String? = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val bandwidth: Int,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val mimeType: String? = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    var qualityRanking: Int? = null,
+    @field:JacksonXmlProperty(isAttribute = true)
+    var frameRate: Double? = null,
+    @field:JacksonXmlProperty(isAttribute = true)
+    var width: Int? = null,
+    @field:JacksonXmlProperty(isAttribute = true)
+    var height: Int? = null,
+)

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/QoeMetricsRequest.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/QoeMetricsRequest.kt
@@ -1,0 +1,21 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class QoeMetricsRequest(
+    var scheme: String = "",
+    var reportPeriod: Long? = 0,
+    var metrics: ArrayList<String>? = ArrayList(),
+    var metricReportingConfigurationId: String? = ""
+) : Parcelable

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/QoeMetricsResponse.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/QoeMetricsResponse.kt
@@ -1,0 +1,19 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class QoeMetricsResponse(
+    var metricsString: String = "",
+    var metricsReportingConfigurationId: String? = ""
+) : Parcelable

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/QoeReport.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/QoeReport.kt
@@ -1,0 +1,40 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+
+data class QoeReport(
+    @field:JacksonXmlElementWrapper(localName = "QoeMetric")
+    @field:JacksonXmlProperty(localName = "HttpList")
+    var httpList: ArrayList<HttpList>? = null,
+
+    @field:JacksonXmlElementWrapper(localName = "QoeMetric")
+    @field:JacksonXmlProperty(localName = "RepSwitchList")
+    var representationSwitchList: ArrayList<RepresentationSwitchList>? = null,
+
+    @field:JacksonXmlElementWrapper(localName = "QoeMetric")
+    @field:JacksonXmlProperty(localName = "BufferLevel")
+    var bufferLevel: ArrayList<BufferLevel>? = null,
+
+    @field:JacksonXmlElementWrapper(localName = "QoeMetric")
+    @field:JacksonXmlProperty(localName = "MPDInformation")
+    var mpdInformation: ArrayList<MpdInformation>? = null,
+
+    @field:JacksonXmlProperty(isAttribute = true, localName = "periodID")
+    var periodId: String = "",
+
+    @field:JacksonXmlProperty(isAttribute = true)
+    var reportTime: String = "",
+
+    @field:JacksonXmlProperty(isAttribute = true)
+    var reportPeriod: Int? = 0,
+)

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/ReceptionReport.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/ReceptionReport.kt
@@ -1,0 +1,39 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
+
+@JacksonXmlRootElement(localName = "ReceptionReport")
+data class ReceptionReport(
+    @field:JacksonXmlElementWrapper(useWrapping = false)
+    @field:JacksonXmlProperty(localName = "QoeReport")
+    var qoeReport: QoeReport,
+
+    @field:JacksonXmlProperty(isAttribute = true, localName = "contentURI")
+    var contentUri: String,
+
+    @field:JacksonXmlProperty(isAttribute = true, localName = "clientID")
+    var clientId: String? = null,
+
+    @field:JacksonXmlProperty(isAttribute = true, localName = "xmlns")
+    var xmlns: String? = null,
+
+    @field:JacksonXmlProperty(isAttribute = true, localName = "xsi:schemaLocation")
+    var schemaLocation: String? = null,
+
+    @field:JacksonXmlProperty(isAttribute = true, localName = "xmlns:xsi")
+    var xsi: String? = null,
+
+    @field:JacksonXmlProperty(isAttribute = true, localName = "xmlns:sv")
+    var sv: String? = null,
+)

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/RepresentationSwitch.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/RepresentationSwitch.kt
@@ -1,0 +1,30 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+
+data class RepresentationSwitchList(
+    @field:JacksonXmlProperty(localName = "RepSwitchEvent")
+    @field:JacksonXmlElementWrapper(useWrapping = false)
+    val entries: ArrayList<RepresentationSwitch>
+)
+
+data class RepresentationSwitch(
+    @field:JacksonXmlProperty(isAttribute = true)
+    val t: String? = null,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val mt: String? = null,
+    @field:JacksonXmlProperty(isAttribute = true)
+    val to: String = "",
+    @field:JacksonXmlProperty(isAttribute = true)
+    val lto: Int? = null
+)

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/SchemeSupport.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/SchemeSupport.kt
@@ -1,3 +1,12 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: Daniel Silhavy
+Copyright: (C) 2023 Fraunhofer FOKUS
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
 package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
 
 import android.os.Parcelable

--- a/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/SchemeSupport.kt
+++ b/app/src/main/java/com/fivegmag/a5gmscommonlibrary/qoeMetricsReporting/SchemeSupport.kt
@@ -1,0 +1,10 @@
+package com.fivegmag.a5gmscommonlibrary.qoeMetricsReporting
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SchemeSupport(
+    val scheme: String,
+    val supported: Boolean
+) : Parcelable


### PR DESCRIPTION
This PR applies the following changes:

* Increases version number to 1.2.0
* Adds required data classes for QoE Metrics Reporting. These classes are used by the MediaStreamHandler and the MediaSessionHandler